### PR TITLE
Default Content-Type to application/json

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -144,6 +144,7 @@ module.exports = class Application extends Emitter {
     if (!this.listenerCount('error')) this.on('error', this.onerror);
 
     const handleRequest = (req, res) => {
+      req.headers["content-type"] = req.headers["content-type"] || "application/json";
       const ctx = this.createContext(req, res);
       return this.handleRequest(ctx, fn);
     };


### PR DESCRIPTION
Currently, if the `Content-Type` header is not specified in any POST/PATCH/PUT, request body data are nullified and not available for further processing. The proposed fix addresses this issue by adding a default `Content-Type` header of `application/json` if none is specified.